### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+# Summary
+
+# Testing Guidance
+


### PR DESCRIPTION
Adds a default PR template for all repos belonging to inferno-framework.

Relevant GitHub Docs:
* [Creating a default community health file](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/creating-a-default-community-health-file)
* [Creating a pull request template for your repository](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository)