### PR TITLE
FI-1952 Add organization profile README

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,19 @@
+<p align="center">
+  <a href="https://inferno-framework.github.io">
+    <img src="https://inferno.healthit.gov/images/inferno_logo.png" alt="Inferno logo" height="150">
+  </a>
+</p>
+
+<p align="center">
+  The Inferno Framework helps you write, execute and share conformance tests<br> for
+  Fast Healthcare Interoperability Resources (FHIR) APIs.
+</p>
+
+<p align="center">
+  <a href="https://inferno-framework.github.io">Learn More</a>
+  &nbsp; -  &nbsp;
+  <a href="https://inferno-framework.github.io/inferno-core/docs/">Reference</a>
+  &nbsp; - &nbsp;
+  <a href="https://inferno-framework.github.io/inferno-core/overview.html#contact-the-inferno-team">Contact</a>
+
+</p>


### PR DESCRIPTION
This should add an [organization-level readme](https://docs.github.com/en/organizations/collaborating-with-groups-in-organizations/customizing-your-organizations-profile) to our [inferno-framework](/inferno-framework) landing page.

It'll look something like this (but not dark-mode obviously, this is just the preview in my editor):
![Screenshot 2023-04-05 at 4 47 01 PM](https://user-images.githubusercontent.com/412901/230208010-601263d4-d0be-4375-a471-c9ec2fcea3b4.png)


